### PR TITLE
[Away] `self.cache` is not initialized when the cog is loaded.

### DIFF
--- a/away/away.py
+++ b/away/away.py
@@ -75,7 +75,7 @@ class Away(commands.Cog):
         self.config.register_guild(**default_guild)
         self.config.register_member(**default_member)
 
-    async def initialize(self):
+    async def cog_load(self):
         self.cache = await self.config.all_guilds()
 
     async def update_guild_cache(self, guild: discord.Guild):


### PR DESCRIPTION
Hello,
This PR renames the `Away.intialize` method to `Away.cog_load` as the method was never loaded before this change. The `delete_after` parameter of the cog was only working in the `[p]away` command.
Have a nice day,
AAA3A